### PR TITLE
feat: Add week numbers and perpetual day indicator to 13-month calendar

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { 
   ChevronLeftIcon, 
   ChevronRightIcon,
@@ -11,6 +11,7 @@ import { monthNames, holidays, getDaysInMonth } from '../utils/calendarData'
 import { getCurrentDate13Month, isSameDate13Month, thirteenMonthToGregorian, gregorianTo13Month } from '../utils/dateConversion'
 import GregorianCalendar from './GregorianCalendar'
 import DatePicker from './DatePicker'
+import PerpetualDayIndicator from './PerpetualDayIndicator'
 
 function Calendar({ theme, setTheme }) {
   const currentDate13Month = getCurrentDate13Month()
@@ -311,7 +312,7 @@ function Calendar({ theme, setTheme }) {
             <p className={`text-sm mt-2 ${
               isBlackIce ? 'text-cyan-200/70' : isDark ? 'text-white/70' : 'text-gray-600'
             }`}>
-              Month {selectedMonth13} of 13
+              Month {selectedMonth13} of 13 • Weeks {(selectedMonth13 - 1) * 4 + 1}-{selectedMonth13 === 13 ? '52' : selectedMonth13 * 4}
             </p>
             {(selectedMonth13 !== currentDate13Month.month || selectedYear13 !== currentDate13Month.year) && (
               <button
@@ -348,7 +349,12 @@ function Calendar({ theme, setTheme }) {
           </button>
         </div>
 
-        <div className="grid grid-cols-7 gap-3">
+        <div className="grid grid-cols-8 gap-3">
+          <div className={`text-center font-semibold text-sm py-3 ${
+            isBlackIce ? 'text-cyan-300/50' : isDark ? 'text-white/50' : 'text-gray-500'
+          }`}>
+            Wk
+          </div>
           {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
             <div key={day} className={`text-center font-semibold text-sm py-3 ${
               isBlackIce ? 'text-cyan-300/70' : isDark ? 'text-white/70' : 'text-gray-700'
@@ -357,14 +363,44 @@ function Calendar({ theme, setTheme }) {
             </div>
           ))}
           
-          {/* Regular 28 days */}
-          {[...Array(28)].map((_, i) => renderDay13Month(i + 1, i))}
+          {/* Render weeks with week numbers */}
+          {[...Array(4)].map((_, weekIndex) => {
+            const weekNumber = (selectedMonth13 - 1) * 4 + weekIndex + 1
+            return (
+              <React.Fragment key={`week-${weekIndex}`}>
+                {/* Week number */}
+                <div className={`aspect-square flex items-center justify-center text-xs font-medium ${
+                  isBlackIce ? 'text-cyan-300/50' : isDark ? 'text-white/50' : 'text-gray-500'
+                }`}>
+                  {weekNumber}
+                </div>
+                {/* Days in the week */}
+                {[...Array(7)].map((_, dayIndex) => {
+                  const dayNum = weekIndex * 7 + dayIndex + 1
+                  return renderDay13Month(dayNum, weekIndex * 7 + dayIndex)
+                })}
+              </React.Fragment>
+            )
+          })}
           
-          {/* New Year's Day (29th) for Yule */}
-          {selectedMonth13 === 13 && renderDay13Month(29, 28)}
-          
-          {/* New Year's Leap (30th) for Yule in leap years */}
-          {selectedMonth13 === 13 && daysInMonth === 30 && renderDay13Month(30, 29)}
+          {/* Special days for Yule with week 52 */}
+          {selectedMonth13 === 13 && (
+            <React.Fragment>
+              <div className={`aspect-square flex items-center justify-center text-xs font-medium ${
+                isBlackIce ? 'text-cyan-300/50' : isDark ? 'text-white/50' : 'text-gray-500'
+              }`}>
+                52
+              </div>
+              {renderDay13Month(29, 28)}
+              {daysInMonth === 30 ? (
+                renderDay13Month(30, 29)
+              ) : (
+                <div /> // Empty cell
+              )}
+              {/* Fill remaining cells */}
+              {[...Array(5)].map((_, i) => <div key={`empty-${i}`} />)}
+            </React.Fragment>
+          )}
         </div>
 
         {selectedMonth13 === 13 && (
@@ -435,6 +471,12 @@ function Calendar({ theme, setTheme }) {
             </div>
           )}
         </div>
+        
+        {/* Perpetual Day Indicator */}
+        <PerpetualDayIndicator 
+          theme={theme} 
+          selectedDay={selectedDate?.day}
+        />
       </>
     )
   }

--- a/src/components/PerpetualDayIndicator.jsx
+++ b/src/components/PerpetualDayIndicator.jsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { CalendarDaysIcon } from '@heroicons/react/24/outline'
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+function PerpetualDayIndicator({ theme, selectedDay }) {
+  const isDark = theme === 'dark' || theme === 'blackice'
+  const isBlackIce = theme === 'blackice'
+  
+  // In the 13-month calendar, the same date falls on the same day every month
+  // Day 1, 8, 15, 22 are always the same day of the week
+  // Day 2, 9, 16, 23 are always the next day, etc.
+  
+  // Calculate which dates fall on the selected day
+  const getDatesForDay = (dayOfWeek) => {
+    const dates = []
+    for (let i = dayOfWeek + 1; i <= 28; i += 7) {
+      dates.push(i)
+    }
+    return dates
+  }
+  
+  return (
+    <div className={`mt-4 backdrop-blur-md rounded-xl p-4 border transition-all duration-300 ${
+      isBlackIce
+        ? 'bg-slate-900/30 border-cyan-500/20'
+        : isDark 
+        ? 'bg-white/5 border-white/10' 
+        : 'bg-white/40 border-gray-300/30'
+    }`}>
+      <div className="flex items-center gap-2 mb-3">
+        <CalendarDaysIcon className={`w-5 h-5 ${
+          isBlackIce ? 'text-cyan-400' : isDark ? 'text-purple-300' : 'text-purple-600'
+        }`} />
+        <h3 className={`text-sm font-semibold ${
+          isBlackIce ? 'text-cyan-100' : isDark ? 'text-white' : 'text-gray-800'
+        }`}>
+          Perpetual Day Pattern
+        </h3>
+      </div>
+      
+      <div className="grid grid-cols-7 gap-2">
+        {dayNames.map((day, index) => {
+          const dates = getDatesForDay(index)
+          const isSelected = selectedDay && dates.includes(selectedDay)
+          
+          return (
+            <div 
+              key={day} 
+              className={`text-center p-2 rounded-lg transition-all duration-200 ${
+                isSelected
+                  ? isBlackIce
+                    ? 'bg-cyan-500/20 border border-cyan-400/50'
+                    : isDark
+                    ? 'bg-purple-500/20 border border-purple-400/50'
+                    : 'bg-purple-100 border border-purple-300'
+                  : ''
+              }`}
+            >
+              <div className={`text-xs font-medium mb-1 ${
+                isBlackIce ? 'text-cyan-300/70' : isDark ? 'text-white/70' : 'text-gray-600'
+              }`}>
+                {day.slice(0, 3)}
+              </div>
+              <div className={`text-xs ${
+                isSelected
+                  ? isBlackIce ? 'text-cyan-100' : isDark ? 'text-white' : 'text-purple-700'
+                  : isBlackIce ? 'text-cyan-200/60' : isDark ? 'text-white/60' : 'text-gray-500'
+              }`}>
+                {dates.join(', ')}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      
+      <p className={`text-xs mt-3 text-center ${
+        isBlackIce ? 'text-cyan-200/50' : isDark ? 'text-white/50' : 'text-gray-500'
+      }`}>
+        In the 13-month calendar, every date falls on the same weekday all year long!
+      </p>
+    </div>
+  )
+}
+
+export default PerpetualDayIndicator


### PR DESCRIPTION
- Added week number column (1-52) to the calendar grid
- Week numbers align perfectly with 13-month structure (4 weeks per month)
- Created PerpetualDayIndicator component showing weekday patterns
- Highlights which dates always fall on the same day of the week
- Shows week range for each month in the header
- Special handling for Yule month (weeks 49-52)
- Maintains theme consistency across all new elements

This showcases a key advantage of the 13-month calendar: perfect weekly alignment\!